### PR TITLE
Find the visual single-band assets

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -112,9 +112,9 @@ class Asset {
    * The RGB bands.
    * 
   * @typedef {Object} VisualBands
-  * @property {BandWithIndex} red The URI
-  * @property {BandWithIndex} green The relation type of the link
-  * @property {BandWithIndex} blue Mediy type of the link
+  * @property {BandWithIndex} red The red band with its index
+  * @property {BandWithIndex} green The green band with its index
+  * @property {BandWithIndex} blue The blue band with its index
   */
 
   /**
@@ -143,16 +143,22 @@ class Asset {
   /**
    * Returns the band for the given criteria.
    * 
-   * Searches the given `property` (default: `name`) for the given string.
+   * Searches the given `property` (default: `name`) for the given value(s).
    * 
-   * @param {*} value 
-   * @param {string} property
+   * @param {*} value A single value to find or a list of values to find one of.
+   * @param {string} property The property in the bands to match against.
+   * @param {Array.<Object>} bands For performance reasons you can provide a list of merged bands from `getBands()`.
    * @returns {BandWithIndex|null}
    * @see {getBands}
    */
-  findBand(value, property = 'name') {
-    let bands = this.getBands();
-    let index = bands.findIndex(band => isObject(band) && band[property] === value);
+  findBand(value, property = 'name', bands = null) {
+    if (!Array.isArray(value)) {
+      value = [value];
+    }
+    if (!isObject(bands)) {
+      bands = this.getBands();
+    }
+    let index = bands.findIndex(band => isObject(band) && value.includes(band[property]));
     if (index >= 0) {
       return { index, band: bands[index] };
     }

--- a/src/stac.js
+++ b/src/stac.js
@@ -320,6 +320,42 @@ class STAC {
   }
 
   /**
+   * The single-band assets for RGB composites.
+   * 
+  * @typedef {Object} VisualAssets
+  * @property {BandWithIndex} red The red band with its index
+  * @property {BandWithIndex} green The green band with its index
+  * @property {BandWithIndex} blue The blue band with its index
+  */
+
+  /**
+   * Find the single-band assets for RGB.
+   * 
+   * @returns {VisualAssets|null} Object with the RGB bands or null
+   */
+  findVisualAssets() {
+    let rgb = {
+      red: false,
+      green: false,
+      blue: false
+    };
+    let names = Object.keys(rgb);
+    let assets = this.getAssets();
+    for(let asset of assets) {
+      let bands = asset.getBands();
+      if (bands.length !== 1) {
+        continue;
+      }
+      let result = asset.findBand(names, 'common_name', bands);
+      if (result) {
+        rgb[result.band.common_name] = asset;
+      }
+    }
+    let complete = Object.values(rgb).every(o => Boolean(o));
+    return complete ? rgb : null;
+  }
+
+  /**
    * 
    * @todo
    * @param {string} rel 

--- a/tests/asset.test.js
+++ b/tests/asset.test.js
@@ -105,6 +105,7 @@ test('findBand', () => {
   expect(asset.findBand("b2")).toEqual(b2i);
   expect(asset.findBand("blue", "common_name")).toEqual(b2i);
   expect(asset.findBand("red", "common_name")).toEqual(b3i);
+  expect(asset.findBand(["foo", "red", "bar"], "common_name")).toEqual(b3i);
 
   expect(asset.findBand("green", "common_name")).toBeNull();
   expect(asset.findBand("b1", "common_name")).toBeNull();

--- a/tests/examples/item-s2.json
+++ b/tests/examples/item-s2.json
@@ -1,0 +1,668 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0-beta.2",
+  "stac_extensions": [
+    "eo",
+    "view",
+    "proj"
+  ],
+  "id": "S2A_19KFA_20230227_0_L2A",
+  "bbox": [
+    -68.05964408799198,
+    -18.17458941618659,
+    -67.01664497565507,
+    -17.174816805049918
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -68.05446998867869,
+          -18.17458941618659
+        ],
+        [
+          -68.05964408799198,
+          -17.182267548812664
+        ],
+        [
+          -67.02749158426681,
+          -17.174816805049918
+        ],
+        [
+          -67.01664497565507,
+          -18.166680021628174
+        ],
+        [
+          -68.05446998867869,
+          -18.17458941618659
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "datetime": "2023-02-27T14:47:44Z",
+    "platform": "sentinel-2a",
+    "constellation": "sentinel-2",
+    "instruments": [
+      "msi"
+    ],
+    "gsd": 10,
+    "view:off_nadir": 0,
+    "proj:epsg": 32719,
+    "sentinel:utm_zone": 19,
+    "sentinel:latitude_band": "K",
+    "sentinel:grid_square": "FA",
+    "sentinel:sequence": "0",
+    "sentinel:product_id": "S2A_MSIL2A_20230227T143721_N0509_R096_T19KFA_20230227T192301",
+    "sentinel:data_coverage": 100,
+    "eo:cloud_cover": 0,
+    "sentinel:valid_cloud_cover": false,
+    "sentinel:processing_baseline": "05.09",
+    "sentinel:boa_offset_applied": true,
+    "created": "2023-02-27T21:18:15.227Z",
+    "updated": "2023-02-27T21:18:15.227Z"
+  },
+  "collection": "sentinel-s2-l2a-cogs",
+  "assets": {
+    "thumbnail": {
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/19/K/FA/2023/2/27/0/preview.jpg"
+    },
+    "overview": {
+      "title": "True color image",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "overview"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/L2A_PVI.tif",
+      "proj:shape": [
+        343,
+        343
+      ],
+      "proj:transform": [
+        320,
+        0,
+        600000,
+        0,
+        -320,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "info": {
+      "title": "Original JSON metadata",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/19/K/FA/2023/2/27/0/tileInfo.json"
+    },
+    "metadata": {
+      "title": "Original XML metadata",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/19/K/FA/2023/2/27/0/metadata.xml"
+    },
+    "visual": {
+      "title": "True color image",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "overview"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/TCI.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B01": {
+      "title": "Band 1 (coastal)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 60,
+      "eo:bands": [
+        {
+          "name": "B01",
+          "common_name": "coastal",
+          "center_wavelength": 0.4439,
+          "full_width_half_max": 0.027
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B01.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60,
+        0,
+        600000,
+        0,
+        -60,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B02": {
+      "title": "Band 2 (blue)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B02.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B03": {
+      "title": "Band 3 (green)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B03.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B04": {
+      "title": "Band 4 (red)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B04.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B05": {
+      "title": "Band 5",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B05",
+          "center_wavelength": 0.7039,
+          "full_width_half_max": 0.019
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B05.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B06": {
+      "title": "Band 6",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B06",
+          "center_wavelength": 0.7402,
+          "full_width_half_max": 0.018
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B06.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B07": {
+      "title": "Band 7",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B07",
+          "center_wavelength": 0.7825,
+          "full_width_half_max": 0.028
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B07.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B08": {
+      "title": "Band 8 (nir)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B08",
+          "common_name": "nir",
+          "center_wavelength": 0.8351,
+          "full_width_half_max": 0.145
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B08.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B8A": {
+      "title": "Band 8A",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B8A",
+          "center_wavelength": 0.8648,
+          "full_width_half_max": 0.033
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B8A.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B09": {
+      "title": "Band 9",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 60,
+      "eo:bands": [
+        {
+          "name": "B09",
+          "center_wavelength": 0.945,
+          "full_width_half_max": 0.026
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B09.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60,
+        0,
+        600000,
+        0,
+        -60,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B11": {
+      "title": "Band 11 (swir16)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B11",
+          "common_name": "swir16",
+          "center_wavelength": 1.6137,
+          "full_width_half_max": 0.143
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B11.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "B12": {
+      "title": "Band 12 (swir22)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B12",
+          "common_name": "swir22",
+          "center_wavelength": 2.22024,
+          "full_width_half_max": 0.242
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/B12.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "AOT": {
+      "title": "Aerosol Optical Thickness (AOT)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/AOT.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60,
+        0,
+        600000,
+        0,
+        -60,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "WVP": {
+      "title": "Water Vapour (WVP)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/WVP.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10,
+        0,
+        600000,
+        0,
+        -10,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    },
+    "SCL": {
+      "title": "Scene Classification Map (SCL)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/SCL.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20,
+        0,
+        600000,
+        0,
+        -20,
+        8100040,
+        0,
+        0,
+        1
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_19KFA_20230227_0_L2A"
+    },
+    {
+      "rel": "canonical",
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/S2A_19KFA_20230227_0_L2A.json",
+      "type": "application/json"
+    },
+    {
+      "title": "sentinel-s2-l2a-aws/workflow-publish-sentinel/tiles-19-K-FA-2023-2-27-0",
+      "rel": "via-cirrus",
+      "href": "https://cirrus-earth-search.aws.element84.com/v0/catid/sentinel-s2-l2a-aws/workflow-publish-sentinel/tiles-19-K-FA-2023-2-27-0"
+    },
+    {
+      "title": "Source STAC Item",
+      "rel": "derived_from",
+      "href": "https://cirrus-v0-data-1qm7gekzjucbq.s3.us-west-2.amazonaws.com/sentinel-s2-l2a/19/K/FA/2023/2/S2A_19KFA_20230227_0_L2A/S2A_19KFA_20230227_0_L2A.json",
+      "type": "application/json"
+    },
+    {
+      "title": "sentinel-s2-l2a/workflow-cog-archive/S2A_19KFA_20230227_0_L2A",
+      "rel": "via-cirrus",
+      "href": "https://cirrus-earth-search.aws.element84.com/v0/catid/sentinel-s2-l2a/workflow-cog-archive/S2A_19KFA_20230227_0_L2A"
+    },
+    {
+      "rel": "parent",
+      "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+    },
+    {
+      "rel": "collection",
+      "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+    },
+    {
+      "rel": "root",
+      "href": "https://earth-search.aws.element84.com/v0/"
+    }
+  ]
+}

--- a/tests/item.test.js
+++ b/tests/item.test.js
@@ -7,6 +7,9 @@ let bbox = [172.91,1.34,172.95,1.36];
 let dtStr = "2020-12-14T18:02:31Z";
 let dtDate = new Date(Date.UTC(2020, 11, 14, 18, 2, 31));
 
+let json2 = JSON.parse(fs.readFileSync('./tests/examples/item-s2.json'));
+let item2 = new Item(json2);
+
 test('Basics', () => {
   expect(item.id).toBe("20201211_223832_CS2");
   expect(item.getMetadata("id")).toBeUndefined();
@@ -66,4 +69,20 @@ test('getDefaultGeoTIFF', () => {
   expect(asset.getKey()).toEqual("visual");
   expect(asset.href).toEqual("./20201211_223832_CS2.tif");
   expect(asset.getAbsoluteUrl()).toEqual("https://example.com/20201211_223832_CS2/20201211_223832_CS2.tif");
+});
+
+describe('findVisualAssets', () => {
+
+  test('item (not found)', () => {
+    expect(item.findVisualAssets()).toBeNull();
+  });
+
+  test('item-s2 (found)', () => {  
+    let assets = item2.findVisualAssets();
+    expect(assets).not.toBeNull();
+    expect(assets.red.getKey()).toBe("B04");
+    expect(assets.blue.getKey()).toBe("B02");
+    expect(assets.green.getKey()).toBe("B03");
+  });
+    
 });


### PR DESCRIPTION
For datasets where each bands is in a separate asset, provide a `findVisualAssets` for STAC Items and Collections in parallel to the `findVisualBands` function in the Asset.

Is this what you were looking for, @tschaub?